### PR TITLE
Replace [u8; 16] with new type DrmKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "^1.0"
 base64 = "0.22.1"
 byteorder = "1"
 bytes = "1.1.0"
+hex = "0.4.3"
 num-rational = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/encryption/drm_key.rs
+++ b/src/encryption/drm_key.rs
@@ -1,0 +1,69 @@
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct DrmKey([u8; 16]);
+
+impl DrmKey {
+    pub fn data(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    pub fn new(data: [u8; 16]) -> Self {
+        DrmKey(data)
+    }
+
+    pub fn from_hex(value: &str) -> Result<Self, DrmKeyError> {
+        let mut key = [0; 16];
+        hex::decode_to_slice(value, &mut key)?;
+
+        Ok(DrmKey(key))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DrmKeyError {
+    #[error(transparent)]
+    InvalidKey(#[from] hex::FromHexError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let key = DrmKey::from_hex("0102030405060708090a0b0c0d0e0f10").unwrap();
+        assert_eq!(
+            key.data(),
+            &[
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
+                0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, //
+            ]
+        );
+    }
+
+    #[test]
+    fn test_invalid_key_length() {
+        let result = DrmKey::from_hex("0102030405060708090a0b0c0d0e0f");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Invalid string length");
+    }
+
+    #[test]
+    fn test_uneven_bytes() {
+        let result = DrmKey::from_hex("1");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Odd number of digits");
+    }
+
+    #[test]
+    fn test_invalid_key() {
+        let result = DrmKey::from_hex("0102030405060708090a0b0c0d0e0fzz");
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid character 'z' at position 30"
+        );
+    }
+}

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -1,2 +1,3 @@
+pub mod drm_key;
 pub mod initialization_vector;
 pub mod sample_encryption;

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -180,7 +180,7 @@ mod tests {
             traks: vec![],
             meta: Some(MetaBox::default()),
             udta: Some(UdtaBox::default()),
-            pssh: vec![PsshBox::default()],
+            pssh: vec![PsshBox::new_clearkey()],
         };
 
         let mut buf = Vec::new();
@@ -192,7 +192,8 @@ mod tests {
         assert_eq!(header.name, BoxType::MoovBox);
         assert_eq!(header.size, src_box.box_size());
 
-        let dst_box = MoovBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
+        let dst_box =
+            MoovBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
         assert_eq!(dst_box, src_box);
     }
 
@@ -209,7 +210,8 @@ mod tests {
         assert_eq!(header.name, BoxType::MoovBox);
         assert_eq!(header.size, src_box.box_size());
 
-        let dst_box = MoovBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
+        let dst_box =
+            MoovBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
         assert_eq!(dst_box, src_box);
     }
 }

--- a/src/mp4box/pssh.rs
+++ b/src/mp4box/pssh.rs
@@ -4,24 +4,32 @@ use base64::{prelude::BASE64_STANDARD, Engine};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 
+use crate::encryption::drm_key::DrmKey;
+
 use super::{
     box_start, skip_bytes_to, write_box_header_ext, BoxHeader, BoxType, Error, Mp4Box, Mp4Context,
     ReadBox, Result, WriteBox, HEADER_EXT_SIZE, HEADER_SIZE,
 };
 
 // ISO 23001-7:2023 - 8.1 Protection System Specific Header Box
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct PsshBox {
     version: u8,
     flags: u32,
 
-    system_id: [u8; 16],
+    system_id: DrmKey,
 
     kid_count: Option<u32>,
-    kid: Vec<[u8; 16]>,
+    kid: Vec<DrmKey>,
 
     data_size: u32,
     data: Vec<u8>,
+}
+
+impl Default for PsshBox {
+    fn default() -> Self {
+        Self::new_clearkey()
+    }
 }
 
 impl PsshBox {
@@ -35,14 +43,13 @@ impl PsshBox {
     }
 
     pub fn new_clearkey() -> Self {
-        let system_id = [
-            0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02, //
-            0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2, 0xfb, 0x4b, //
-        ];
-        Self::new(system_id, vec![])
+        Self::new(
+            DrmKey::from_hex("1077efecc0b24d02ace33c1e52e2fb4b").expect("always valid"),
+            vec![],
+        )
     }
 
-    pub fn new(system_id: [u8; 16], data: Vec<u8>) -> Self {
+    pub fn new(system_id: DrmKey, data: Vec<u8>) -> Self {
         PsshBox {
             version: 0,
             flags: 0,
@@ -57,7 +64,7 @@ impl PsshBox {
         }
     }
 
-    pub fn with_kid(system_id: [u8; 16], kid: Vec<[u8; 16]>, data: Vec<u8>) -> Self {
+    pub fn with_kid(system_id: DrmKey, kid: Vec<DrmKey>, data: Vec<u8>) -> Self {
         PsshBox {
             version: 1,
             flags: 0,
@@ -70,14 +77,6 @@ impl PsshBox {
             data_size: data.len() as u32,
             data,
         }
-    }
-
-    pub fn get_kid(&self) -> &Vec<[u8; 16]> {
-        &self.kid
-    }
-
-    pub fn get_system_id(&self) -> &[u8; 16] {
-        &self.system_id
     }
 
     pub fn get_type(&self) -> BoxType {
@@ -135,7 +134,10 @@ impl<R: Read + Seek> ReadBox<&mut R> for PsshBox {
             for i in 0..kid_count {
                 reader.read_exact(&mut kid[i as usize])?;
             }
-            (Some(kid_count), kid)
+            (
+                Some(kid_count),
+                kid.iter().map(|x| DrmKey::new(*x)).collect(),
+            )
         } else {
             (None, Vec::new())
         };
@@ -149,7 +151,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for PsshBox {
         Ok(PsshBox {
             version,
             flags,
-            system_id,
+            system_id: DrmKey::new(system_id),
             kid_count,
             kid,
             data_size,
@@ -166,7 +168,7 @@ impl<W: Write> WriteBox<&mut W> for PsshBox {
 
         write_box_header_ext(writer, self.version, self.flags)?;
 
-        writer.write_all(&self.system_id)?;
+        writer.write_all(self.system_id.data())?;
 
         if self.version > 0 {
             let kid_count = match self.kid_count {
@@ -177,7 +179,7 @@ impl<W: Write> WriteBox<&mut W> for PsshBox {
             writer.write_u32::<BigEndian>(kid_count)?;
 
             for i in 0..kid_count {
-                writer.write_all(&self.kid[i as usize])?;
+                writer.write_all(self.kid[i as usize].data())?;
             }
         }
 
@@ -196,10 +198,10 @@ mod tests {
 
     #[test]
     fn test_pssh() {
-        let system_id = [
+        let system_id = DrmKey::new([
             0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02, //
             0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2, 0xfb, 0x4b,
-        ];
+        ]);
 
         let data = vec![
             0x6d, 0x76, 0xf2, 0x5c, 0xb1, 0x7f, 0x5e, 0x16, //
@@ -233,15 +235,15 @@ mod tests {
 
     #[test]
     fn test_pssh_with_kid() {
-        let kid = vec![[
+        let kid = vec![DrmKey::new([
             0x6d, 0x76, 0xf2, 0x5c, 0xb1, 0x7f, 0x5e, 0x16, //
             0xb8, 0xea, 0xef, 0x6b, 0xbf, 0x58, 0x2d, 0x8e,
-        ]];
+        ])];
 
-        let system_id = [
+        let system_id = DrmKey::new([
             0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02, //
             0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2, 0xfb, 0x4b,
-        ];
+        ]);
 
         let src_box = PsshBox::with_kid(system_id, kid, Vec::new());
 
@@ -278,8 +280,8 @@ mod tests {
         let pssh = PsshBox::from_base64(base64).unwrap();
 
         assert_eq!(
-            pssh.system_id,
-            [
+            pssh.system_id.data(),
+            &[
                 0xed, 0xef, 0x8b, 0xa9, 0x79, 0xd6, 0x4a, 0xce, //
                 0xa3, 0xc8, 0x27, 0xdc, 0xd5, 0x1d, 0x21, 0xed //
             ]
@@ -295,8 +297,8 @@ mod tests {
         let pssh = PsshBox::from_base64(base64).unwrap();
 
         assert_eq!(
-            pssh.system_id,
-            [
+            pssh.system_id.data(),
+            &[
                 0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40, 0x42, 0x86, //
                 0xab, 0x92, 0xe6, 0x5b, 0xe0, 0x88, 0x5f, 0x95 //
             ]

--- a/src/mp4box/pssh.rs
+++ b/src/mp4box/pssh.rs
@@ -26,12 +26,6 @@ pub struct PsshBox {
     data: Vec<u8>,
 }
 
-impl Default for PsshBox {
-    fn default() -> Self {
-        Self::new_clearkey()
-    }
-}
-
 impl PsshBox {
     pub fn from_base64(base64: &str) -> Result<Self> {
         let data = BASE64_STANDARD.decode(base64.as_bytes())?;

--- a/src/mp4box/schi.rs
+++ b/src/mp4box/schi.rs
@@ -8,7 +8,7 @@ use super::{
 };
 
 // ISO 14496-12:2022 - 8.12.7 Scheme Information Box
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SchiBox {
     pub tenc: TencBox,
 }
@@ -107,7 +107,8 @@ mod tests {
         assert_eq!(header.name, BoxType::SchiBox);
         assert_eq!(src_box.box_size(), header.size);
 
-        let dst_box = SchiBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
+        let dst_box =
+            SchiBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
         assert_eq!(src_box, dst_box);
     }
 }

--- a/src/mp4box/tenc.rs
+++ b/src/mp4box/tenc.rs
@@ -229,12 +229,6 @@ impl<W: Write> WriteBox<&mut W> for TencBox {
     }
 }
 
-impl Default for TencBox {
-    fn default() -> Self {
-        Self::new_unprotected()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mp4box/tenc.rs
+++ b/src/mp4box/tenc.rs
@@ -3,6 +3,8 @@ use std::io::{Read, Seek, Write};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 
+use crate::encryption::drm_key::DrmKey;
+
 use super::{
     box_start, encryption::initialization_vector::InitializationVector, read_box_header_ext,
     skip_bytes_to, write_box_header_ext, BoxHeader, BoxType, Error, Mp4Box, Mp4Context, ReadBox,
@@ -10,7 +12,7 @@ use super::{
 };
 
 // ISO 23001-7:2023 - 8.2 Track Encryption Box
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TencBox {
     default_crypt_byte_block: Option<u8>,
     default_skip_byte_block: Option<u8>,
@@ -20,7 +22,7 @@ pub struct TencBox {
     // 8: 64-bit IVs
     // 16: 128-bit IVs
     pub(crate) default_per_sample_iv_size: u8,
-    default_kid: [u8; 16],
+    default_kid: DrmKey,
 
     // 8: 64-bit IVs
     // 16: 128-bit IVs
@@ -36,21 +38,24 @@ impl TencBox {
 
             default_is_protected: false,
             default_per_sample_iv_size: 0,
-            default_kid: [0; 16],
+            default_kid: DrmKey::new([0; 16]),
 
             default_constant_iv_size: None,
             default_constant_iv: None,
         }
     }
 
-    pub fn new_kid_protected(iv: InitializationVector) -> Self {
+    pub fn new_per_sample_iv_protected(
+        default_per_sample_iv_size: u8,
+        default_kid: DrmKey,
+    ) -> Self {
         TencBox {
             default_crypt_byte_block: None,
             default_skip_byte_block: None,
 
             default_is_protected: true,
-            default_per_sample_iv_size: iv.size(),
-            default_kid: iv.data(),
+            default_per_sample_iv_size,
+            default_kid,
 
             default_constant_iv_size: None,
             default_constant_iv: None,
@@ -59,7 +64,7 @@ impl TencBox {
 
     pub fn new_constant_iv_protected(
         iv: InitializationVector,
-        default_kid: [u8; 16],
+        default_kid: DrmKey,
         crypt: Option<u8>,
         skip: Option<u8>,
     ) -> Self {
@@ -168,7 +173,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TencBox {
             default_skip_byte_block,
             default_is_protected,
             default_per_sample_iv_size,
-            default_kid,
+            default_kid: DrmKey::new(default_kid),
             default_constant_iv_size,
             default_constant_iv,
         })
@@ -204,7 +209,7 @@ impl<W: Write> WriteBox<&mut W> for TencBox {
 
         writer.write_u8(self.default_per_sample_iv_size)?;
 
-        writer.write_all(&self.default_kid)?;
+        writer.write_all(self.default_kid.data())?;
 
         if self.default_is_protected && self.default_per_sample_iv_size == 0 {
             match (&self.default_constant_iv_size, &self.default_constant_iv) {
@@ -221,6 +226,12 @@ impl<W: Write> WriteBox<&mut W> for TencBox {
         }
 
         Ok(size)
+    }
+}
+
+impl Default for TencBox {
+    fn default() -> Self {
+        Self::new_unprotected()
     }
 }
 
@@ -258,42 +269,12 @@ mod tests {
     }
 
     #[test]
-    fn test_tenc_kid_64() {
-        let data = [
-            0x6d, 0x76, 0xf2, 0x5c, 0xb1, 0x7f, 0x5e, 0x16, //
-        ];
-        let src_box = TencBox::new_kid_protected(InitializationVector::new_64_bit(data));
-
-        let mut buf = Vec::new();
-        src_box.write_box(&mut buf).unwrap();
-        assert_eq!(buf.len(), src_box.box_size() as usize);
-
-        let expected = vec![
-            0x00, 0x00, 0x00, 0x20, b't', b'e', b'n', b'c', //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08, //
-            0x6d, 0x76, 0xf2, 0x5c, 0xb1, 0x7f, 0x5e, 0x16, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
-        ];
-
-        assert_eq!(buf, expected);
-
-        let mut reader = Cursor::new(&buf);
-        let header = BoxHeader::read(&mut reader).unwrap();
-        assert_eq!(header.name, BoxType::TencBox);
-        assert_eq!(src_box.box_size(), header.size);
-
-        let dst_box =
-            TencBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
-        assert_eq!(src_box, dst_box);
-    }
-
-    #[test]
     fn test_tenc_kid_128() {
         let data = [
             0x6d, 0x76, 0xf2, 0x5c, 0xb1, 0x7f, 0x5e, 0x16, //
             0xb8, 0xea, 0xef, 0x6b, 0xbf, 0x58, 0x2d, 0x8e, //
         ];
-        let src_box = TencBox::new_kid_protected(InitializationVector::new_128_bit(data));
+        let src_box = TencBox::new_per_sample_iv_protected(16, DrmKey::new(data));
 
         let mut buf = Vec::new();
         src_box.write_box(&mut buf).unwrap();
@@ -325,7 +306,7 @@ mod tests {
         ];
         let src_box = TencBox::new_constant_iv_protected(
             InitializationVector::new_64_bit(data),
-            [0; 16],
+            DrmKey::new([0; 16]),
             Some(1),
             Some(9),
         );
@@ -363,7 +344,10 @@ mod tests {
         ];
         let src_box = TencBox::new_constant_iv_protected(
             InitializationVector::new_128_bit(data),
-            [0; 16],
+            DrmKey::new([
+                0xae, 0xfb, 0x53, 0xb5, 0xa6, 0x67, 0x4f, 0xc0, //
+                0xb7, 0x7d, 0x47, 0x20, 0xe5, 0xac, 0x87, 0xfb, //
+            ]),
             Some(1),
             Some(9),
         );
@@ -375,8 +359,8 @@ mod tests {
         let expected = vec![
             0x00, 0x00, 0x00, 0x31, b't', b'e', b'n', b'c', //
             0x01, 0x00, 0x00, 0x00, 0x00, 0x19, 0x01, 0x00, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+            0xae, 0xfb, 0x53, 0xb5, 0xa6, 0x67, 0x4f, 0xc0, //
+            0xb7, 0x7d, 0x47, 0x20, 0xe5, 0xac, 0x87, 0xfb, //
             0x10, 0x6d, 0x76, 0xf2, 0x5c, 0xb1, 0x7f, 0x5e, //
             0x16, 0xb8, 0xea, 0xef, 0x6b, 0xbf, 0x58, 0x2d, //
             0x8e,


### PR DESCRIPTION
Makes it a bit more clean in this library, and will make it a lot cleaner when using DRM in the packager.

Also fixes issue with tenc box constructor (see comment below).