### PR TITLE
Add serialization for DrmKey, InitializationVector and PSSH box

### DIFF
--- a/src/encryption/drm_key.rs
+++ b/src/encryption/drm_key.rs
@@ -1,7 +1,10 @@
-use serde::Serialize;
+use std::{convert::TryFrom, fmt::Display};
+
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Hash)]
+#[serde(try_from = "String")]
 pub struct DrmKey([u8; 16]);
 
 impl DrmKey {
@@ -18,6 +21,34 @@ impl DrmKey {
         hex::decode_to_slice(value, &mut key)?;
 
         Ok(DrmKey(key))
+    }
+}
+
+impl Display for DrmKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        hex::encode(self.data()).fmt(f)
+    }
+}
+
+impl TryFrom<&str> for DrmKey {
+    type Error = DrmKeyError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_hex(value)
+    }
+}
+
+impl TryFrom<String> for DrmKey {
+    type Error = DrmKeyError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_hex(&value)
+    }
+}
+
+impl Serialize for DrmKey {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&self)
     }
 }
 

--- a/src/encryption/initialization_vector.rs
+++ b/src/encryption/initialization_vector.rs
@@ -1,9 +1,10 @@
-use std::fmt::Display;
+use std::{convert::TryFrom, fmt::Display};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
+#[serde(try_from = "String")]
 pub struct InitializationVector {
     value: u128,
     size: u8,
@@ -22,6 +23,10 @@ impl InitializationVector {
             value: u128::from_be_bytes(data),
             size: 16,
         }
+    }
+
+    pub fn from_hex(data: &str) -> Result<Self, InitializationVectorError> {
+        Self::new(hex::decode(data)?)
     }
 
     pub fn new(data: Vec<u8>) -> Result<Self, InitializationVectorError> {
@@ -79,11 +84,29 @@ impl InitializationVector {
 
 impl Display for InitializationVector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for b in self.data() {
-            write!(f, "{:02x}", b)?;
-        }
+        hex::encode(self.data()).fmt(f)
+    }
+}
 
-        Ok(())
+impl Serialize for InitializationVector {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&self)
+    }
+}
+
+impl TryFrom<&str> for InitializationVector {
+    type Error = InitializationVectorError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_hex(value)
+    }
+}
+
+impl TryFrom<String> for InitializationVector {
+    type Error = InitializationVectorError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_hex(&value)
     }
 }
 
@@ -91,6 +114,8 @@ impl Display for InitializationVector {
 pub enum InitializationVectorError {
     #[error("Invalid size: {0}")]
     InvalidSize(u8),
+    #[error(transparent)]
+    InvalidKey(#[from] hex::FromHexError),
 }
 
 #[cfg(test)]

--- a/src/mp4box/pssh.rs
+++ b/src/mp4box/pssh.rs
@@ -90,11 +90,11 @@ impl PsshBox {
         HEADER_SIZE + HEADER_EXT_SIZE + 16 + kid_size + data_size
     }
 
-    pub fn to_base64(&self) -> String {
+    pub fn to_base64(&self) -> Result<String> {
         let mut buf = Vec::new();
-        self.write_box(&mut buf).unwrap();
+        self.write_box(&mut buf)?;
 
-        BASE64_STANDARD.encode(&buf)
+        Ok(BASE64_STANDARD.encode(&buf))
     }
 }
 
@@ -196,7 +196,8 @@ impl Serialize for PsshBox {
     where
         S: serde::Serializer,
     {
-        serializer.collect_str(&self.to_base64())
+        let base64 = self.to_base64().map_err(serde::ser::Error::custom)?;
+        serializer.collect_str(&base64)
     }
 }
 

--- a/src/mp4box/pssh.rs
+++ b/src/mp4box/pssh.rs
@@ -2,7 +2,7 @@ use std::io::{Cursor, Read, Seek, Write};
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use serde::Serialize;
+use serde::{de, Serialize};
 
 use crate::encryption::drm_key::DrmKey;
 
@@ -12,7 +12,7 @@ use super::{
 };
 
 // ISO 23001-7:2023 - 8.1 Protection System Specific Header Box
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PsshBox {
     version: u8,
     flags: u32,
@@ -88,6 +88,13 @@ impl PsshBox {
         let data_size = 4 + self.data_size as u64;
 
         HEADER_SIZE + HEADER_EXT_SIZE + 16 + kid_size + data_size
+    }
+
+    pub fn to_base64(&self) -> String {
+        let mut buf = Vec::new();
+        self.write_box(&mut buf).unwrap();
+
+        BASE64_STANDARD.encode(&buf)
     }
 }
 
@@ -181,6 +188,25 @@ impl<W: Write> WriteBox<&mut W> for PsshBox {
         writer.write_all(&self.data)?;
 
         Ok(size)
+    }
+}
+
+impl Serialize for PsshBox {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&self.to_base64())
+    }
+}
+
+impl<'de> de::Deserialize<'de> for PsshBox {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_base64(&s).map_err(|err| <D::Error as serde::de::Error>::custom(err.to_string()))
     }
 }
 


### PR DESCRIPTION
InitializationVector and DrmKey are serialized as hex-encoded strings.
The PSSH box is encoded as base64 to make interfacing with EZDRM even more EZ.

Will allow for configuring DRM in the packager like this

![image](https://github.com/user-attachments/assets/807ddd0e-363a-4ba5-b901-9f4bb96a0d70)
