### PR TITLE
Add support for saiz and saio

### DIFF
--- a/src/cmaf/cmaf_chunk_writer.rs
+++ b/src/cmaf/cmaf_chunk_writer.rs
@@ -279,22 +279,23 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
                     .as_ref()
                     .map_or(0, |iv| iv.size()),
             ));
-
-            self.traf.saio.get_or_insert(saio::SaioBox::new(0));
-
-            let saiz = self.traf.saiz.get_or_insert(saiz::SaizBox::new(0));
-
             senc.add_iv(encryption.clone());
 
-            saiz.add_sample_info_size(2 + 6 * encryption.sub_samples().len() as u8);
+            if use_subsample_encryption {
+                self.traf.saio.get_or_insert(saio::SaioBox::new(0));
 
-            // It's important that the saio offset is updated after all other fields have been set
-            let offset = HEADER_SIZE + MFHD_SIZE + self.traf.get_saio_offset();
-            self.traf
-                .saio
-                .as_mut()
-                .expect("guaranteed insert above")
-                .set_single_offset(offset);
+                let saiz = self.traf.saiz.get_or_insert(saiz::SaizBox::new(0));
+
+                saiz.add_sample_info_size(2 + 6 * encryption.sub_samples().len() as u8);
+
+                // It's important that the saio offset is updated after all other fields have been set
+                let offset = HEADER_SIZE + MFHD_SIZE + self.traf.get_saio_offset();
+                self.traf
+                    .saio
+                    .as_mut()
+                    .expect("guaranteed insert above")
+                    .set_single_offset(offset);
+            }
         }
 
         Ok(duration as u64)

--- a/src/cmaf/cmaf_chunk_writer.rs
+++ b/src/cmaf/cmaf_chunk_writer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use prft::PrftBox;
 
-use crate::mfhd::MfhdBox;
+use crate::mfhd::{MfhdBox, MFHD_SIZE};
 use crate::mp4box::traf::TrafBox;
 use crate::tfhd::TfhdBox;
 use crate::trun::TrunBox;
@@ -153,6 +153,7 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
             trun: None,
             senc: None,
             saiz: None,
+            saio: None,
         };
 
         let mfhd = MfhdBox {
@@ -235,20 +236,6 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
     }
 
     pub fn write_sample(&mut self, sample: &Mp4Sample) -> Result<u64> {
-        if let Some(encryption) = &sample.encryption {
-            let use_subsample_encryption = !encryption.subsamples.is_empty();
-            let senc = self.traf.senc.get_or_insert(senc::SencBox::new(
-                use_subsample_encryption,
-                encryption
-                    .initialization_vector
-                    .as_ref()
-                    .map_or(0, |iv| iv.size()),
-            ));
-
-            // We could also add a saiz box here, but it doesn't seem to be needed, and I have no idea what to put for sample size
-            senc.add_iv(encryption.clone());
-        }
-
         self.samples.push(sample.bytes.clone());
         self.traf.tfdt.get_or_insert(tfdt::TfdtBox {
             version: 1,
@@ -282,6 +269,34 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
         }
 
         let duration: u32 = trun.duration();
+
+        if let Some(encryption) = &sample.encryption {
+            let use_subsample_encryption = !encryption.subsamples.is_empty();
+            let senc = self.traf.senc.get_or_insert(senc::SencBox::new(
+                use_subsample_encryption,
+                encryption
+                    .initialization_vector
+                    .as_ref()
+                    .map_or(0, |iv| iv.size()),
+            ));
+
+            self.traf.saio.get_or_insert(saio::SaioBox::new(0));
+
+            let saiz = self.traf.saiz.get_or_insert(saiz::SaizBox::new(0));
+
+            senc.add_iv(encryption.clone());
+
+            saiz.add_sample_info_size(2 + 6 * encryption.sub_samples().len() as u8);
+
+            // It's important that the saio offset is updated after all other fields have been set
+            let offset = HEADER_SIZE + MFHD_SIZE + self.traf.get_saio_offset();
+            self.traf
+                .saio
+                .as_mut()
+                .expect("guaranteed insert above")
+                .set_single_offset(offset);
+        }
+
         Ok(duration as u64)
     }
 

--- a/src/mp4box/mfhd.rs
+++ b/src/mp4box/mfhd.rs
@@ -4,6 +4,8 @@ use std::io::{Read, Seek, Write};
 
 use crate::mp4box::*;
 
+pub const MFHD_SIZE: u64 = HEADER_SIZE + HEADER_EXT_SIZE + 4;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct MfhdBox {
     pub version: u8,
@@ -27,7 +29,7 @@ impl MfhdBox {
     }
 
     pub fn get_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4
+        MFHD_SIZE
     }
 }
 
@@ -101,7 +103,8 @@ mod tests {
         assert_eq!(header.name, BoxType::MfhdBox);
         assert_eq!(src_box.box_size(), header.size);
 
-        let dst_box = MfhdBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
+        let dst_box =
+            MfhdBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
         assert_eq!(src_box, dst_box);
     }
 }

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -94,6 +94,7 @@ pub(crate) mod pasp;
 pub mod prft;
 pub mod pssh;
 pub(crate) mod psuedo_boxes;
+pub(crate) mod saio;
 pub(crate) mod saiz;
 pub mod schi;
 pub mod schm;
@@ -270,7 +271,8 @@ boxtype! {
     EncvBox => 0x656e6376,
     EncaBox => 0x656e6361,
     SencBox => 0x73656e63,
-    SaizBox => 0x7361697A
+    SaizBox => 0x7361697A,
+    SaioBox => 0x7361696F
 }
 
 pub trait Mp4Box: Sized {

--- a/src/mp4box/saio.rs
+++ b/src/mp4box/saio.rs
@@ -1,0 +1,188 @@
+use std::{
+    io::{Read, Seek, Write},
+    vec,
+};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use serde::Serialize;
+
+use super::{
+    box_start, read_box_header_ext, skip_bytes_to, write_box_header_ext, BoxHeader, BoxType,
+    Mp4Box, Mp4Context, ReadBox, Result, WriteBox, HEADER_EXT_SIZE, HEADER_SIZE,
+};
+
+// ISO 23001-7:2023 - 8.2 Track Encryption Box
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct SaioBox {
+    aux_info_type: Option<u32>,
+    aux_info_type_parameter: Option<u32>,
+    version: u8,
+    offsets: Vec<u64>,
+}
+
+impl SaioBox {
+    pub fn new(version: u8) -> Self {
+        SaioBox {
+            aux_info_type: None,
+            aux_info_type_parameter: None,
+            version,
+            offsets: vec![],
+        }
+    }
+
+    pub fn set_single_offset(&mut self, offset: u64) {
+        self.offsets = vec![offset];
+    }
+
+    pub fn get_type(&self) -> BoxType {
+        BoxType::SaioBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+
+        if self.aux_info_type.is_some() && self.aux_info_type_parameter.is_some() {
+            size += 8;
+        }
+
+        // entry_count
+        size += 4;
+
+        if self.version == 0 {
+            size += self.offsets.len() as u64 * 4;
+        } else {
+            size += self.offsets.len() as u64 * 8;
+        }
+
+        size
+    }
+}
+
+impl Mp4Box for SaioBox {
+    fn box_type(&self) -> BoxType {
+        self.get_type()
+    }
+
+    fn box_size(&self) -> u64 {
+        self.get_size()
+    }
+
+    fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self).unwrap())
+    }
+
+    fn summary(&self) -> Result<String> {
+        Ok("".to_string())
+    }
+}
+
+impl<R: Read + Seek> ReadBox<&mut R> for SaioBox {
+    fn read_box(reader: &mut R, size: u64, _context: &mut Mp4Context) -> Result<Self> {
+        let start = box_start(reader)?;
+
+        let (version, flags) = read_box_header_ext(reader)?;
+
+        let (aux_info_type, aux_info_type_parameter) = if flags & 1 == 1 {
+            let aux_info_type = reader.read_u32::<BigEndian>()?;
+            let aux_info_type_parameter = reader.read_u32::<BigEndian>()?;
+
+            (Some(aux_info_type), Some(aux_info_type_parameter))
+        } else {
+            (None, None)
+        };
+
+        let entry_count = reader.read_u32::<BigEndian>()?;
+        let mut offsets = vec![];
+
+        for _ in 0..entry_count {
+            let offset = if version == 0 {
+                reader.read_u32::<BigEndian>()? as u64
+            } else {
+                reader.read_u64::<BigEndian>()?
+            };
+            offsets.push(offset);
+        }
+
+        skip_bytes_to(reader, start + size)?;
+
+        Ok(SaioBox {
+            aux_info_type,
+            aux_info_type_parameter,
+            offsets,
+            version,
+        })
+    }
+}
+
+impl<W: Write> WriteBox<&mut W> for SaioBox {
+    fn write_box(&self, writer: &mut W) -> Result<u64> {
+        let size = self.box_size();
+
+        BoxHeader::new(self.box_type(), size).write(writer)?;
+
+        let flags = if self.aux_info_type.is_some() && self.aux_info_type_parameter.is_some() {
+            1
+        } else {
+            0
+        };
+
+        write_box_header_ext(writer, self.version, flags)?;
+
+        if let (Some(aux_info_type), Some(aux_info_type_parameter)) =
+            (self.aux_info_type, self.aux_info_type_parameter)
+        {
+            writer.write_u32::<BigEndian>(aux_info_type)?;
+            writer.write_u32::<BigEndian>(aux_info_type_parameter)?;
+        }
+
+        writer.write_u32::<BigEndian>(self.offsets.len() as u32)?;
+
+        for offset in &self.offsets {
+            if self.version == 0 {
+                writer.write_u32::<BigEndian>(*offset as u32)?;
+            } else {
+                writer.write_u64::<BigEndian>(*offset)?;
+            }
+        }
+
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4box::BoxHeader;
+    use std::{io::Cursor, vec};
+
+    #[test]
+    fn test_saio() {
+        let src_box = SaioBox {
+            aux_info_type: None,
+            aux_info_type_parameter: None,
+            offsets: vec![3745],
+            version: 0,
+        };
+
+        let mut buf = Vec::new();
+        src_box.write_box(&mut buf).unwrap();
+        assert_eq!(buf.len(), src_box.box_size() as usize);
+
+        let expected = vec![
+            0x00, 0x00, 0x00, 0x14, 0x73, 0x61, 0x69, 0x6f, // header
+            0x00, 0x00, 0x00, 0x00, // ext header
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x0e, 0xa1,
+        ];
+
+        assert_eq!(buf, expected);
+
+        let mut reader = Cursor::new(&buf);
+        let header = BoxHeader::read(&mut reader).unwrap();
+        assert_eq!(header.name, BoxType::SaioBox);
+        assert_eq!(src_box.box_size(), header.size);
+
+        let dst_box =
+            SaioBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
+        assert_eq!(src_box, dst_box);
+    }
+}

--- a/src/mp4box/saiz.rs
+++ b/src/mp4box/saiz.rs
@@ -14,7 +14,6 @@ pub struct SaizBox {
     aux_info_type: Option<u32>,
     aux_info_type_parameter: Option<u32>,
     default_sample_info_size: u8,
-    sample_count: u32,
     sample_info_sizes: Vec<u8>,
 }
 
@@ -24,13 +23,12 @@ impl SaizBox {
             aux_info_type: None,
             aux_info_type_parameter: None,
             default_sample_info_size,
-            sample_count: 0,
             sample_info_sizes: vec![],
         }
     }
 
-    pub fn increment_sample_count(&mut self) {
-        self.sample_count += 1;
+    pub fn add_sample_info_size(&mut self, size: u8) {
+        self.sample_info_sizes.push(size);
     }
 
     pub fn get_type(&self) -> BoxType {
@@ -38,13 +36,19 @@ impl SaizBox {
     }
 
     pub fn get_size(&self) -> u64 {
-        let mut size = HEADER_SIZE + HEADER_EXT_SIZE + 1 + 4;
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
         if let (Some(_), Some(_)) = (self.aux_info_type, self.aux_info_type_parameter) {
             size += 8
         }
 
+        // default_sample_info_size
+        size += 1;
+
+        // sample_count
+        size += 4;
+
         if self.default_sample_info_size == 0 {
-            size += self.sample_count as u64;
+            size += self.sample_info_sizes.len() as u64;
         }
 
         size
@@ -99,7 +103,6 @@ impl<R: Read + Seek> ReadBox<&mut R> for SaizBox {
             aux_info_type,
             aux_info_type_parameter,
             default_sample_info_size,
-            sample_count,
             sample_info_sizes,
         })
     }
@@ -127,7 +130,7 @@ impl<W: Write> WriteBox<&mut W> for SaizBox {
         }
 
         writer.write_u8(self.default_sample_info_size)?;
-        writer.write_u32::<BigEndian>(self.sample_count)?;
+        writer.write_u32::<BigEndian>(self.sample_info_sizes.len() as u32)?;
 
         if self.default_sample_info_size == 0 {
             for sample_info_size in &self.sample_info_sizes {
@@ -151,7 +154,6 @@ mod tests {
             aux_info_type: None,
             aux_info_type_parameter: None,
             default_sample_info_size: 8,
-            sample_count: 0,
             sample_info_sizes: vec![],
         };
 
@@ -183,7 +185,6 @@ mod tests {
             aux_info_type: Some(1),
             aux_info_type_parameter: Some(1),
             default_sample_info_size: 8,
-            sample_count: 0,
             sample_info_sizes: vec![],
         };
 
@@ -217,8 +218,7 @@ mod tests {
             aux_info_type: None,
             aux_info_type_parameter: None,
             default_sample_info_size: 0,
-            sample_count: 2,
-            sample_info_sizes: vec![1, 2],
+            sample_info_sizes: vec![32, 32, 32],
         };
 
         let mut buf = Vec::new();
@@ -226,10 +226,10 @@ mod tests {
         assert_eq!(buf.len(), src_box.box_size() as usize);
 
         let expected = vec![
-            0x00, 0x00, 0x00, 0x13, b's', b'a', b'i', b'z', // header
+            0x00, 0x00, 0x00, 0x14, b's', b'a', b'i', b'z', // header
             0x00, 0x00, 0x00, 0x00, // ext header
-            0x00, 0x00, 0x00, 0x00, 0x02, //
-            0x01, 0x02,
+            0x00, 0x00, 0x00, 0x00, 0x03, //
+            0x20, 0x20, 0x20,
         ];
 
         assert_eq!(buf, expected);

--- a/src/mp4box/traf.rs
+++ b/src/mp4box/traf.rs
@@ -6,6 +6,7 @@ use tracing::debug;
 use crate::mp4box::*;
 use crate::mp4box::{tfdt::TfdtBox, tfhd::TfhdBox, trun::TrunBox};
 
+use super::saio::SaioBox;
 use super::saiz::SaizBox;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
@@ -16,6 +17,7 @@ pub struct TrafBox {
 
     pub senc: Option<SencBox>,
     pub saiz: Option<SaizBox>,
+    pub saio: Option<SaioBox>,
 }
 
 impl TrafBox {
@@ -32,13 +34,30 @@ impl TrafBox {
         if let Some(ref trun) = self.trun {
             size += trun.box_size();
         }
-        if let Some(ref senc) = self.senc {
-            size += senc.box_size();
-        }
         if let Some(ref saiz) = self.saiz {
             size += saiz.box_size();
         }
+        if let Some(ref saio) = self.saio {
+            size += saio.box_size();
+        }
+        if let Some(ref senc) = self.senc {
+            size += senc.box_size();
+        }
         size
+    }
+
+    /// Gets offset to be used in saio box.
+    /// It's the offset from the begging of the moof box to 16 bytes
+    /// into the senc box (where the sample data begins).
+    pub fn get_saio_offset(&self) -> u64 {
+        let Some(ref senc) = self.senc else {
+            return 0;
+        };
+
+        let mut end = self.get_size();
+        end -= senc.box_size();
+        end += 16; // 16 bytes into the senc box
+        end
     }
 }
 
@@ -70,6 +89,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
         let mut trun = None;
         let mut senc = None;
         let mut saiz = None;
+        let mut saio = None;
 
         let mut current = reader.stream_position()?;
         let end = start + size;
@@ -131,6 +151,13 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
             saiz = Some(SaizBox::read_box(reader, s, context)?);
         }
 
+        if let Some(saio_start) = boxes.remove(&BoxType::SaioBox) {
+            reader.seek(SeekFrom::Start(saio_start))?;
+            let header = BoxHeader::read(reader)?;
+            let BoxHeader { name: _, size: s } = header;
+            saio = Some(SaioBox::read_box(reader, s, context)?);
+        }
+
         for (name, _) in boxes {
             debug!("Skipping box: {:?}", name);
         }
@@ -143,6 +170,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
             trun,
             senc,
             saiz,
+            saio,
         })
     }
 }
@@ -162,12 +190,16 @@ impl<W: Write> WriteBox<&mut W> for TrafBox {
             trun.write_box(writer)?;
         }
 
-        if let Some(ref senc) = self.senc {
-            senc.write_box(writer)?;
-        }
-
         if let Some(ref saiz) = self.saiz {
             saiz.write_box(writer)?;
+        }
+
+        if let Some(ref saio) = self.saio {
+            saio.write_box(writer)?;
+        }
+
+        if let Some(ref senc) = self.senc {
+            senc.write_box(writer)?;
         }
 
         Ok(size)


### PR DESCRIPTION
# What
Adds support for saiz and saio boxes.

These boxes can together tell where subsample decryption information can be found.

# Why
FFmpeg, Chrome, Safari, Edge and most other browsers are able to find this data (in the `senc` box) without these boxes.

But Firefox isn't able to. See https://bugzilla.mozilla.org/show_bug.cgi?id=1505675.

# How to test

See https://github.com/RealSprint/vindral-packager/pull/1143