### PR TITLE
Add support for styp

### DIFF
--- a/src/cmaf/cmaf_chunk_writer.rs
+++ b/src/cmaf/cmaf_chunk_writer.rs
@@ -205,7 +205,7 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
             styp: StypBox(GeneralTypeBox {
                 major_brand: cmaf_header_config.major_brand,
                 minor_version: cmaf_header_config.minor_version,
-                compatible_brands: cmaf_header_config.compatible_brands.clone(),
+                compatible_brands,
             }),
             emsgs: vec![],
             samples: vec![],

--- a/src/cmaf/cmaf_chunk_writer.rs
+++ b/src/cmaf/cmaf_chunk_writer.rs
@@ -11,6 +11,21 @@ use crate::tfhd::TfhdBox;
 use crate::trun::TrunBox;
 use crate::*;
 
+// ISO 23001-19:2024 - 7.3.2.3
+pub const CMAF_CHUNK_IDENTIFIER: FourCC = FourCC {
+    value: [b'c', b'm', b'f', b'l'],
+};
+
+// ISO 23001-19:2024 - 7.3.2.4
+pub const CMAF_FRAGMENT_IDENTIFIER: FourCC = FourCC {
+    value: [b'c', b'm', b'f', b'f'],
+};
+
+// ISO 23001-19:2024 - 7.3.3.1
+pub const CMAF_SEGMENT_IDENTIFIER: FourCC = FourCC {
+    value: [b'c', b'm', b'f', b's'],
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CmafChunkConfig {
     pub timescale: u32,
@@ -131,14 +146,19 @@ pub struct CmafChunkWriter<W> {
     traf: TrafBox,
     mfhd: MfhdBox,
     prft: Option<PrftBox>,
-    styp: Option<StypBox>,
+    styp: StypBox,
     emsgs: Vec<EmsgBox>,
     samples: Vec<Bytes>,
     timescale: u32,
 }
 
 impl<W: Write + Seek> CmafChunkWriter<W> {
-    pub fn write_start(writer: W, track_id: u32, config: &CmafChunkConfig) -> Result<Self> {
+    pub fn write_start(
+        writer: W,
+        track_id: u32,
+        config: &CmafChunkConfig,
+        cmaf_header_config: CmafHeaderConfig,
+    ) -> Result<Self> {
         let tfhd = TfhdBox {
             track_id,
             flags: TfhdBox::FLAG_DEFAULT_SAMPLE_FLAGS
@@ -174,24 +194,23 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
             media_time: prt.media_time,
         });
 
+        let mut compatible_brands = cmaf_header_config.compatible_brands.clone();
+        compatible_brands.push(CMAF_CHUNK_IDENTIFIER);
+
         Ok(CmafChunkWriter {
             writer,
             traf,
             mfhd,
             prft,
-            styp: None,
+            styp: StypBox(GeneralTypeBox {
+                major_brand: cmaf_header_config.major_brand,
+                minor_version: cmaf_header_config.minor_version,
+                compatible_brands: cmaf_header_config.compatible_brands.clone(),
+            }),
             emsgs: vec![],
             samples: vec![],
             timescale: config.timescale,
         })
-    }
-
-    pub fn mark_new_segment(&mut self, cmaf_header_config: CmafHeaderConfig) {
-        self.styp = Some(StypBox(GeneralTypeBox {
-            major_brand: cmaf_header_config.major_brand,
-            minor_version: cmaf_header_config.minor_version,
-            compatible_brands: cmaf_header_config.compatible_brands,
-        }));
     }
 
     pub fn producer_reference_time(&self) -> Option<&PrftBox> {
@@ -319,9 +338,7 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
     }
 
     pub fn write_end(&mut self, sequence_number: u32) -> Result<()> {
-        if let Some(styp) = self.styp.as_ref() {
-            styp.write_box(&mut self.writer)?;
-        }
+        self.styp.write_box(&mut self.writer)?;
 
         self.mfhd.sequence_number = sequence_number;
 
@@ -361,6 +378,14 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
 
     pub fn into_writer(self) -> W {
         self.writer
+    }
+
+    pub fn mark_new_fragment(&mut self) {
+        self.styp.0.compatible_brands.push(CMAF_FRAGMENT_IDENTIFIER);
+    }
+
+    pub fn mark_new_segment(&mut self) {
+        self.styp.0.compatible_brands.push(CMAF_SEGMENT_IDENTIFIER);
     }
 }
 
@@ -427,7 +452,22 @@ mod tests {
         let mut data = Cursor::new(data);
         data.set_position(size as u64);
 
-        let mut writer = CmafChunkWriter::write_start(data, 1, &config)?;
+        let mut writer = CmafChunkWriter::write_start(
+            data,
+            1,
+            &config,
+            CmafHeaderConfig {
+                compatible_brands: vec![
+                    str::parse("iso6").unwrap(),
+                    str::parse("cmfc").unwrap(),
+                    str::parse("mp41").unwrap(),
+                ],
+                major_brand: str::parse("iso6").unwrap(),
+                minor_version: 512,
+                timescale: 1000,
+                pssh: Vec::new(),
+            },
+        )?;
 
         writer.write_sample(&Mp4Sample {
             start_time: 10,

--- a/src/cmaf/cmaf_chunk_writer.rs
+++ b/src/cmaf/cmaf_chunk_writer.rs
@@ -5,6 +5,8 @@ use prft::PrftBox;
 
 use crate::mfhd::{MfhdBox, MFHD_SIZE};
 use crate::mp4box::traf::TrafBox;
+use crate::psuedo_boxes::general_type_box::GeneralTypeBox;
+use crate::styp::StypBox;
 use crate::tfhd::TfhdBox;
 use crate::trun::TrunBox;
 use crate::*;
@@ -129,6 +131,7 @@ pub struct CmafChunkWriter<W> {
     traf: TrafBox,
     mfhd: MfhdBox,
     prft: Option<PrftBox>,
+    styp: Option<StypBox>,
     emsgs: Vec<EmsgBox>,
     samples: Vec<Bytes>,
     timescale: u32,
@@ -176,10 +179,19 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
             traf,
             mfhd,
             prft,
+            styp: None,
             emsgs: vec![],
             samples: vec![],
             timescale: config.timescale,
         })
+    }
+
+    pub fn mark_new_segment(&mut self, cmaf_header_config: CmafHeaderConfig) {
+        self.styp = Some(StypBox(GeneralTypeBox {
+            major_brand: cmaf_header_config.major_brand,
+            minor_version: cmaf_header_config.minor_version,
+            compatible_brands: cmaf_header_config.compatible_brands,
+        }));
     }
 
     pub fn producer_reference_time(&self) -> Option<&PrftBox> {
@@ -307,6 +319,10 @@ impl<W: Write + Seek> CmafChunkWriter<W> {
     }
 
     pub fn write_end(&mut self, sequence_number: u32) -> Result<()> {
+        if let Some(styp) = self.styp.as_ref() {
+            styp.write_box(&mut self.writer)?;
+        }
+
         self.mfhd.sequence_number = sequence_number;
 
         let mut moof = MoofBox {

--- a/src/cmaf/cmaf_header_writer.rs
+++ b/src/cmaf/cmaf_header_writer.rs
@@ -5,6 +5,7 @@ use pssh::PsshBox;
 
 use crate::mp4box::*;
 use crate::mvex::MvexBox;
+use crate::psuedo_boxes::general_type_box::GeneralTypeBox;
 use crate::track::Mp4TrackWriter;
 use crate::trex::TrexBox;
 use crate::*;
@@ -71,11 +72,11 @@ impl<W: Write + Seek> CmafHeaderWriter<W> {
         config: &CmafHeaderConfig,
         duration: Option<Duration>,
     ) -> Result<Self> {
-        let ftyp = FtypBox {
+        let ftyp = FtypBox(GeneralTypeBox {
             major_brand: config.major_brand,
             minor_version: config.minor_version,
             compatible_brands: config.compatible_brands.clone(),
-        };
+        });
         ftyp.write_box(&mut writer)?;
 
         let tracks = Vec::new();

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -108,6 +108,7 @@ pub(crate) mod stsd;
 pub(crate) mod stss;
 pub(crate) mod stsz;
 pub(crate) mod stts;
+pub(crate) mod styp;
 pub mod tenc;
 pub(crate) mod tfdt;
 pub(crate) mod tfhd;
@@ -272,7 +273,8 @@ boxtype! {
     EncaBox => 0x656e6361,
     SencBox => 0x73656e63,
     SaizBox => 0x7361697A,
-    SaioBox => 0x7361696F
+    SaioBox => 0x7361696F,
+    StypBox => 0x73747970
 }
 
 pub trait Mp4Box: Sized {

--- a/src/mp4box/psuedo_boxes/general_type_box.rs
+++ b/src/mp4box/psuedo_boxes/general_type_box.rs
@@ -1,0 +1,83 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use serde::Serialize;
+use std::io::{Read, Seek, Write};
+
+use crate::mp4box::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct GeneralTypeBox {
+    pub major_brand: FourCC,
+    pub minor_version: u32,
+    pub compatible_brands: Vec<FourCC>,
+}
+
+pub enum GeneralTypeBoxType {
+    FtypBox,
+    StypBox,
+}
+
+impl GeneralTypeBox {
+    pub fn get_size(&self) -> u64 {
+        HEADER_SIZE + 8 + (4 * self.compatible_brands.len() as u64)
+    }
+
+    pub fn summary(&self) -> Result<String> {
+        let mut compatible_brands = Vec::new();
+        for brand in self.compatible_brands.iter() {
+            compatible_brands.push(brand.to_string());
+        }
+        let s = format!(
+            "major_brand={} minor_version={} compatible_brands={}",
+            self.major_brand,
+            self.minor_version,
+            compatible_brands.join("-")
+        );
+        Ok(s)
+    }
+
+    pub fn write_box<W: Write>(&self, writer: &mut W, kind: GeneralTypeBoxType) -> Result<u64> {
+        let box_type = match kind {
+            GeneralTypeBoxType::FtypBox => BoxType::FtypBox,
+            GeneralTypeBoxType::StypBox => BoxType::StypBox,
+        };
+
+        let size = self.get_size();
+        BoxHeader::new(box_type, size).write(writer)?;
+
+        writer.write_u32::<BigEndian>((&self.major_brand).into())?;
+        writer.write_u32::<BigEndian>(self.minor_version)?;
+        for b in self.compatible_brands.iter() {
+            writer.write_u32::<BigEndian>(b.into())?;
+        }
+        Ok(size)
+    }
+
+    pub fn read_box<R: Read + Seek>(
+        reader: &mut R,
+        size: u64,
+        _context: &mut Mp4Context,
+    ) -> Result<Self> {
+        let start = box_start(reader)?;
+
+        if size < 16 || size % 4 != 0 {
+            return Err(Error::InvalidData("ftyp size too small or not aligned"));
+        }
+        let brand_count = (size - 16) / 4; // header + major + minor
+        let major = reader.read_u32::<BigEndian>()?;
+        let minor = reader.read_u32::<BigEndian>()?;
+
+        let mut brands = Vec::new();
+        for _ in 0..brand_count {
+            let b = reader.read_u32::<BigEndian>()?;
+            brands.push(From::from(b));
+        }
+
+        skip_bytes_to(reader, start + size)?;
+
+        Ok(GeneralTypeBox {
+            major_brand: From::from(major),
+            minor_version: minor,
+            compatible_brands: brands,
+        })
+    }
+}

--- a/src/mp4box/psuedo_boxes/general_type_box.rs
+++ b/src/mp4box/psuedo_boxes/general_type_box.rs
@@ -60,7 +60,9 @@ impl GeneralTypeBox {
         let start = box_start(reader)?;
 
         if size < 16 || size % 4 != 0 {
-            return Err(Error::InvalidData("ftyp size too small or not aligned"));
+            return Err(Error::InvalidData(
+                "ftyp/styp size too small or not aligned",
+            ));
         }
         let brand_count = (size - 16) / 4; // header + major + minor
         let major = reader.read_u32::<BigEndian>()?;

--- a/src/mp4box/psuedo_boxes/mod.rs
+++ b/src/mp4box/psuedo_boxes/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod general_type_box;
 pub(crate) mod sample_entry;

--- a/src/mp4box/styp.rs
+++ b/src/mp4box/styp.rs
@@ -1,19 +1,16 @@
 use serde::Serialize;
-use std::{
-    io::{Read, Seek, Write},
-    ops::Deref,
-};
+use std::io::{Read, Seek, Write};
 
 use crate::mp4box::*;
 
 use super::psuedo_boxes::general_type_box::{GeneralTypeBox, GeneralTypeBoxType};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
-pub struct FtypBox(pub GeneralTypeBox);
+pub struct StypBox(pub GeneralTypeBox);
 
-impl FtypBox {
+impl StypBox {
     pub fn get_type(&self) -> BoxType {
-        BoxType::FtypBox
+        BoxType::StypBox
     }
 
     pub fn get_size(&self) -> u64 {
@@ -21,7 +18,7 @@ impl FtypBox {
     }
 }
 
-impl Mp4Box for FtypBox {
+impl Mp4Box for StypBox {
     fn box_type(&self) -> BoxType {
         self.get_type()
     }
@@ -39,23 +36,15 @@ impl Mp4Box for FtypBox {
     }
 }
 
-impl Deref for FtypBox {
-    type Target = GeneralTypeBox;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<R: Read + Seek> ReadBox<&mut R> for FtypBox {
+impl<R: Read + Seek> ReadBox<&mut R> for StypBox {
     fn read_box(reader: &mut R, size: u64, context: &mut Mp4Context) -> Result<Self> {
         Ok(Self(GeneralTypeBox::read_box(reader, size, context)?))
     }
 }
 
-impl<W: Write> WriteBox<&mut W> for FtypBox {
+impl<W: Write> WriteBox<&mut W> for StypBox {
     fn write_box(&self, writer: &mut W) -> Result<u64> {
-        self.0.write_box(writer, GeneralTypeBoxType::FtypBox)
+        self.0.write_box(writer, GeneralTypeBoxType::StypBox)
     }
 }
 
@@ -66,8 +55,8 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_ftyp() {
-        let src_box = FtypBox(GeneralTypeBox {
+    fn test_styp() {
+        let src_box = StypBox(GeneralTypeBox {
             major_brand: str::parse("isom").unwrap(),
             minor_version: 0,
             compatible_brands: vec![
@@ -83,11 +72,11 @@ mod tests {
 
         let mut reader = Cursor::new(&buf);
         let header = BoxHeader::read(&mut reader).unwrap();
-        assert_eq!(header.name, BoxType::FtypBox);
+        assert_eq!(header.name, BoxType::StypBox);
         assert_eq!(src_box.box_size(), header.size);
 
         let dst_box =
-            FtypBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
+            StypBox::read_box(&mut reader, header.size, &mut Mp4Context::default()).unwrap();
         assert_eq!(src_box, dst_box);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -6,6 +6,7 @@ use prft::PrftBox;
 use tracing::debug;
 
 use crate::meta::MetaBox;
+use crate::styp::StypBox;
 use crate::*;
 
 #[derive(Debug)]
@@ -16,6 +17,7 @@ pub struct Mp4Reader<R> {
     pub moofs: Vec<MoofBox>,
     pub prfts: Vec<PrftBox>,
     pub emsgs: Vec<EmsgBox>,
+    pub styp: Option<StypBox>,
 
     tracks: HashMap<u32, Mp4Track>,
     size: u64,
@@ -56,6 +58,7 @@ impl<R: Read + Seek> Mp4Reader<R> {
                 BoxType::FtypBox => {
                     ftyp = Some(FtypBox::read_box(&mut reader, s, &mut context)?);
                 }
+
                 BoxType::FreeBox => {
                     skip_box(&mut reader, s)?;
                 }
@@ -143,6 +146,7 @@ impl<R: Read + Seek> Mp4Reader<R> {
         Ok(Mp4Reader {
             reader,
             ftyp: ftyp.unwrap(),
+            styp: None,
             moov: moov.unwrap(),
             moofs,
             emsgs,
@@ -160,6 +164,7 @@ impl<R: Read + Seek> Mp4Reader<R> {
     ) -> Result<Mp4Reader<FR>> {
         let start = reader.stream_position()?;
 
+        let mut styp = None;
         let mut moofs = Vec::new();
         let mut prfts = Vec::new();
         let mut moof_offsets = Vec::new();
@@ -186,6 +191,9 @@ impl<R: Read + Seek> Mp4Reader<R> {
             match name {
                 BoxType::MdatBox => {
                     skip_box(&mut reader, s)?;
+                }
+                BoxType::StypBox => {
+                    styp = Some(StypBox::read_box(&mut reader, s, &mut context)?);
                 }
                 BoxType::EmsgBox => {
                     let emsg = EmsgBox::read_box(&mut reader, s, &mut context)?;
@@ -250,6 +258,7 @@ impl<R: Read + Seek> Mp4Reader<R> {
         Ok(Mp4Reader {
             reader,
             ftyp: self.ftyp.clone(),
+            styp,
             moov: self.moov.clone(),
             moofs,
             emsgs,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -3,6 +3,7 @@ use pssh::PsshBox;
 use std::io::{Seek, SeekFrom, Write};
 
 use crate::mp4box::*;
+use crate::psuedo_boxes::general_type_box::GeneralTypeBox;
 use crate::track::Mp4TrackWriter;
 use crate::*;
 
@@ -65,11 +66,11 @@ impl<W> Mp4Writer<W> {
 
 impl<W: Write + Seek> Mp4Writer<W> {
     pub fn write_start(mut writer: W, config: &Mp4Config) -> Result<Self> {
-        let ftyp = FtypBox {
+        let ftyp = FtypBox(GeneralTypeBox {
             major_brand: config.major_brand,
             minor_version: config.minor_version,
             compatible_brands: config.compatible_brands.clone(),
-        };
+        });
         ftyp.write_box(&mut writer)?;
 
         // TODO largesize


### PR DESCRIPTION
## What

### Adds support for `styp` box 
Adds the `styp` box, which is identical to the `ftyp` box.
Extracted and reused the present code for reading/writing `ftyp`.

### Adds support for marking new fragments and segments
Added new methods on the cmaf chunk writer to mark a new fragment/segment.

This adds the different `compatible_brands` specified in ISO 23001-19:2024.

