### PR TITLE
Fix bad calculation of saio box size

### DIFF
--- a/src/mp4box/saio.rs
+++ b/src/mp4box/saio.rs
@@ -26,7 +26,7 @@ impl SaioBox {
             aux_info_type: None,
             aux_info_type_parameter: None,
             version,
-            offsets: vec![],
+            offsets: vec![0],
         }
     }
 


### PR DESCRIPTION
We calculate the saio offset based on the size of the saio box itself.

This has been working quite well, as there are always multiple samples per `moof`, except when using av1 where we sometimes get only one, and in this case the size is calculated without a offset being present, causing the size to be off by 4 bytes.

This causes issues with DRM playback for AV1 on Firefox and Safari