### PR TITLE
fix: avoid panics when reading samples from malformed/edge input

### DIFF
--- a/src/track.rs
+++ b/src/track.rs
@@ -808,6 +808,11 @@ impl Mp4Track {
         reader: &mut R,
         sample_id: u32,
     ) -> Result<Option<Mp4Sample>> {
+        // Sample IDs are 1-based; sample_id 0 would underflow `sample_id - 1`
+        // in the offset/time lookups below.
+        if sample_id == 0 {
+            return Ok(None);
+        }
         let sample_offset = match self.sample_offset(sample_id) {
             Ok(offset) => offset,
             Err(Error::EntryInStblNotFound(_, _, _)) => return Ok(None),
@@ -823,7 +828,11 @@ impl Mp4Track {
         reader.seek(SeekFrom::Start(sample_offset))?;
         reader.read_exact(&mut buffer)?;
 
-        let (start_time, duration) = self.sample_time(sample_id).unwrap(); // XXX
+        let (start_time, duration) = match self.sample_time(sample_id) {
+            Ok(t) => t,
+            Err(Error::EntryInStblNotFound(_, _, _)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
         let rendering_offset = self.sample_rendering_offset(sample_id);
         let is_sync = self.is_sync_sample(sample_id);
 

--- a/src/track.rs
+++ b/src/track.rs
@@ -808,8 +808,7 @@ impl Mp4Track {
         reader: &mut R,
         sample_id: u32,
     ) -> Result<Option<Mp4Sample>> {
-        // Sample IDs are 1-based; sample_id 0 would underflow `sample_id - 1`
-        // in the offset/time lookups below.
+        // Sample ids are 1-based.
         if sample_id == 0 {
             return Ok(None);
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -214,8 +214,6 @@ fn test_read_fragments() {
     let eos = mp4_fragment.read_sample(1, 2);
     assert!(eos.is_err());
 
-    // sample_id is 1-based; reading sample 0 must not panic. Without the guard
-    // this underflows `sample_id - 1` in the fragment sample lookup (a panic
-    // under debug overflow checks).
+    // Sample ids are 1-based; reading sample 0 must not panic.
     assert!(mp4_fragment.read_sample(1, 0).unwrap().is_none());
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -213,4 +213,9 @@ fn test_read_fragments() {
     );
     let eos = mp4_fragment.read_sample(1, 2);
     assert!(eos.is_err());
+
+    // sample_id is 1-based; reading sample 0 must not panic. Without the guard
+    // this underflows `sample_id - 1` in the fragment sample lookup (a panic
+    // under debug overflow checks).
+    assert!(mp4_fragment.read_sample(1, 0).unwrap().is_none());
 }


### PR DESCRIPTION
Follow-up from the unwrap/panic audit.

### Audit result
Reviewed the ~109 non-test `.unwrap()` sites for panics reachable from
untrusted input. The codebase is **much better defended than the raw count
suggests**:
- Required-child-box unwraps in every `read_box` are preceded by an
  `is_none()` guard returning `Error::BoxNotFound` — no panic on a missing box.
- `BoxHeader::read` unwraps `try_into` on slices of a fixed `[u8; 8]` buffer —
  infallible.
- Sample-access unwraps are protected by `find_traf_idx_and_sample_idx`, which
  only yields trafs whose `trun` is `Some`, and by `checked_add` + `InvalidData`
  for arithmetic.
- The 63 `to_json` unwraps serialize the crate's own structs — effectively
  infallible.

### The two real panics fixed
1. **`Mp4Track::read_sample` unwrapped `sample_time()`** (the author marked it
   `// XXX`), unlike the adjacent `sample_offset()`/`sample_size()` calls that
   map `EntryInStblNotFound` → `Ok(None)`. A malformed file whose `stts` is
   inconsistent with the size/offset tables panicked. Now handled identically.
2. **`read_sample(_, 0)`** reached `sample_id - 1` (sample IDs are 1-based) and
   underflowed — a panic under debug overflow checks. Guarded at the entry,
   returning `Ok(None)`.

### Test
Adds a regression test reading sample `0` from a fragmented file; it panics at
`track.rs:540` ("attempt to subtract with overflow") without the guard and
passes with it. Full suite green.

### Note
Targets `cmaf`; best merged after #26 (which activates CI on `cmaf`) so the
pipeline runs on this PR after a rebase.